### PR TITLE
Improve hierarchy indexing

### DIFF
--- a/getAllJobTitlesCSV.php
+++ b/getAllJobTitlesCSV.php
@@ -55,7 +55,7 @@ function buildHierarchy($employees, $group_presidents) {
         if (!empty($employee['supervisor_email'])) {
             $supervisor_email = strtolower(trim($employee['supervisor_email']));
             if (isset($lookup[$supervisor_email])) {
-                $lookup[$supervisor_email]['subordinates'][] = &$employee;
+                $lookup[$supervisor_email]['subordinates'][$email] = &$employee;
             }
         }
     }
@@ -63,9 +63,9 @@ function buildHierarchy($employees, $group_presidents) {
     return $tree;
 }
 
-function countEmployees(&$node) {
+function countEmployees($node) {
     $count = 0;
-    foreach ($node['subordinates'] as &$subordinate) {
+    foreach ($node['subordinates'] as $subordinate) {
         $count += 1 + countEmployees($subordinate);
     }
     return $count;
@@ -81,7 +81,7 @@ function getTitlesByLevel(&$node, $level = 1, &$titlesByLevel = []) {
     }
     $titlesByLevel[$level][$node['job_title']]++;
     
-    foreach ($node['subordinates'] as &$subordinate) {
+    foreach ($node['subordinates'] as $subordinate) {
         getTitlesByLevel($subordinate, $level + 1, $titlesByLevel);
     }
     

--- a/getMahajanEmails.php
+++ b/getMahajanEmails.php
@@ -23,6 +23,7 @@ function readCSV($filename) {
 function buildHierarchy($employees) {
     $lookup = [];
     $tree = [];
+
     foreach ($employees as $emp) {
         if (!isset($emp['employee_email'])) {
             continue;
@@ -31,11 +32,12 @@ function buildHierarchy($employees) {
         $emp['subordinates'] = [];
         $lookup[$email] = $emp;
     }
+
     foreach ($lookup as $email => &$emp) {
         if (!empty($emp['supervisor_email'])) {
             $super = strtolower(trim($emp['supervisor_email']));
             if (isset($lookup[$super])) {
-                $lookup[$super]['subordinates'][] = &$emp;
+                $lookup[$super]['subordinates'][$email] = &$emp;
             } else {
                 $tree[$email] = &$emp;
             }
@@ -43,15 +45,32 @@ function buildHierarchy($employees) {
             $tree[$email] = &$emp;
         }
     }
+
     return $tree;
 }
 
-function gatherEmails(&$node, $divisionMatch, &$emails = []) {
+function findNode($tree, $email) {
+    $email = strtolower(trim($email));
+    if (isset($tree[$email])) {
+        return $tree[$email];
+    }
+    foreach ($tree as $node) {
+        if (!empty($node['subordinates'])) {
+            $found = findNode($node['subordinates'], $email);
+            if ($found !== null) {
+                return $found;
+            }
+        }
+    }
+    return null;
+}
+
+function gatherEmails($node, $divisionMatch, &$emails = []) {
     $division = isset($node['division']) ? strtolower($node['division']) : '';
     if (strpos($division, strtolower($divisionMatch)) !== false) {
         $emails[] = strtolower($node['employee_email']);
     }
-    foreach ($node['subordinates'] as &$sub) {
+    foreach ($node['subordinates'] as $sub) {
         gatherEmails($sub, $divisionMatch, $emails);
     }
     return $emails;
@@ -63,11 +82,13 @@ $hierarchy = buildHierarchy($employees);
 $manager = 'crothenbuhler@baymark.com';
 $manager = strtolower($manager);
 $emails = [];
-	print_r($hierarchy);
-if (isset($hierarchy[$manager])) {
-	$emails = gatherEmails($hierarchy[$manager], 'Mahajan');
+
+print_r($hierarchy);
+$branch = findNode($hierarchy, $manager);
+if ($branch !== null) {
+    $emails = gatherEmails($branch, 'Mahajan');
 } else {
-	echo "$manager not found\n";
+    echo "$manager not found\n";
 }
 echo implode("\n", $emails);
 


### PR DESCRIPTION
## Summary
- key hierarchy nodes by employee email instead of numeric indices
- add recursive search helper for finding managers in hierarchy
- update traversal to use associative subordinate lists

## Testing
- `php -l getMahajanEmails.php`
- `php -l getAllJobTitlesCSV.php`


------
https://chatgpt.com/codex/tasks/task_e_6842e2859bac8320b0eed3f3af02a792